### PR TITLE
Update PHP to support proxies

### DIFF
--- a/php/PaypalIPN.php
+++ b/php/PaypalIPN.php
@@ -6,6 +6,10 @@ class PaypalIPN
     private $use_sandbox = false;
     /** @var bool Indicates if the local certificates are used. */
     private $use_local_certs = true;
+    /** @var $use_proxy Indicates the proxy to use, if any */
+    private $use_proxy = null;
+    /** @var bool $use_proxy_tunnel Indicates if proxy tunnel is used */
+    private $use_proxy_tunnel = false;
 
     /** Production Postback URL */
     const VERIFY_URI = 'https://ipnpb.paypal.com/cgi-bin/webscr';
@@ -35,6 +39,25 @@ class PaypalIPN
     public function usePHPCerts()
     {
         $this->use_local_certs = false;
+    }
+    
+    /**
+     * Sets curl to use the given proxy
+     * @return void
+     */
+    public function useProxy($proxy_url)
+    {
+        $this->use_proxy = $proxy_url;
+    }
+    
+    /**
+     * Sets curl to use the proxy as a tunnel (i.e., to use
+     * HTTP CONNECT protocol)
+     * @return void
+     */
+    public function useProxyTunnel()
+    {
+        $this->use_proxy_tunnel = true;
     }
 
     /**
@@ -104,6 +127,14 @@ class PaypalIPN
         curl_setopt($ch, CURLOPT_SSLVERSION, 6);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 1);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+        
+        if (isset($this->use_proxy)) {
+            curl_setopt($ch, CURLOPT_PROXY, $this->use_proxy);
+            if ($this->use_proxy_tunnel) {
+                curl_setopt($ch, CURLOPT_HTTPPROXYTUNNEL , true);
+            }
+        }
+
 
         // This is often required if the server is missing a global cert bundle, or is using an outdated one.
         if ($this->use_local_certs) {


### PR DESCRIPTION
Some sites restrict outgoing network access on their servers that deal with payments, requiring such access to go through proxies that vet the destinations before allowing access. This update changes the PHP sample to support such proxy use.

This just handles the simple cases where you can set all of your proxy information via the CURLOPT_PROXY option, which should cover many basic proxy cases, and the case where you need to set the CURLOPT_HTTPPROXYTUNNEL option to make it use the CONNECT protocol. I believe that will cover a large fraction of the cases people will commonly encounter.

An alternative approach, if supporting all of the plethora of proxy options PHP curl has is desired, would be to instead change verifyIPN() so that it can optionally accept a curl object, which if given it uses instead of calling curl_init() itself. A caller who wanted to use a proxy could handle creating the curl object and then set whatever options they want before calling verifyIPN().